### PR TITLE
Streamlit host config

### DIFF
--- a/backends/advanced/.env.template
+++ b/backends/advanced/.env.template
@@ -79,8 +79,8 @@ DEBUG_DIR=./data/debug_dir
 # CROPPING_CONTEXT_PADDING=0.1
 
 # Server settings
-# HOST=0.0.0.0
-# PORT=8000
+HOST_IP=0.0.0.0
+PORT=8000
 
 # Memory settings
 # MEM0_TELEMETRY=False

--- a/backends/advanced/docker-compose.yml
+++ b/backends/advanced/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - "8501:8501"
     environment:
       - BACKEND_API_URL=http://friend-backend:8000
-      - BACKEND_PUBLIC_URL=http://100.99.62.5:8000 # Your BROWSER should be able to access this (Only for displaying audio)
+      - BACKEND_PUBLIC_URL=http://${HOST_IP}:${PORT} # Your BROWSER should be able to access this (Only for displaying audio)
       - STREAMLIT_SERVER_ENABLE_CORS=false
     depends_on:
       friend-backend:

--- a/backends/advanced/pyproject.toml
+++ b/backends/advanced/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "aiohttp>=3.8.0",
     "fastapi-users[beanie]>=14.0.1",
     "PyYAML>=6.0.1",
+    "rank_bm25>=0.2.2"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Streamlit would not display the audio files without the host ip being correct.  This was hardcoded in the docker-compose, so I've externalised this to the .env to increase visibility.
Also, when I tried to build the project it said I needed rank_bm25.  no idea what this is but I added it