### PR TITLE
Added .env in docker compose, tweaked readme

### DIFF
--- a/extras/speaker-recognition/README.md
+++ b/extras/speaker-recognition/README.md
@@ -15,6 +15,10 @@ cp .env.template .env
 # Edit .env and add your Hugging Face token
 ```
 Get your HF token from https://huggingface.co/settings/tokens
+Accept the terms and conditions for 
+https://huggingface.co/pyannote/speaker-diarization-3.1
+https://huggingface.co/pyannote/segmentation-3.0
+
 
 ### 2. Choose CPU or GPU setup
 ```bash
@@ -24,6 +28,8 @@ uv sync --group cpu
 # For GPU acceleration (requires NVIDIA GPU + CUDA)
 uv sync --group gpu
 ```
+
+If you choose GPU, uncomment the deploy section with GPU requirements from docker-compose.yml
 
 ### 3. Initialize HTTPS (Required for Microphone Access)
 

--- a/extras/speaker-recognition/docker-compose.yml
+++ b/extras/speaker-recognition/docker-compose.yml
@@ -1,30 +1,21 @@
 services:
-  # FastAPI Speaker Recognition Service
+  # Base Speaker Recognition Service Configuration
   speaker-service:
+    &base-speaker-service
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        COMPUTE_MODE: ${COMPUTE_MODE:-cpu}
     image: speaker-recognition:latest
+    env_file:
+      - .env
     ports:
       - "${SPEAKER_SERVICE_PORT:-8085}:${SPEAKER_SERVICE_PORT:-8085}"
     volumes:
-      # Mount source code for development (live reload)
       - ./src:/app/src
-      # Persist Hugging Face cache (models) between restarts
       - ./model_cache:/models
       - ./audio_chunks:/app/audio_chunks
       - ./debug:/app/debug
-      # Persist speaker database (faiss.index + speakers.json)
       - ./speaker_data:/app/data
-    deploy:
-          resources:
-            reservations:
-              devices:
-                - driver: nvidia
-                  count: all
-                  capabilities: [gpu]
     environment:
       - HF_HOME=/models
       - HF_TOKEN=${HF_TOKEN}
@@ -38,16 +29,43 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+
+  # CPU Profile Configuration
+  speaker-service-cpu:
+    <<: *base-speaker-service
+    profiles: ["cpu"]
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        COMPUTE_MODE: cpu
+
+  # GPU Profile Configuration
+  speaker-service-gpu:
+    <<: *base-speaker-service
+    profiles: ["gpu"]
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        COMPUTE_MODE: gpu
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
   
   # React Web UI
   web-ui:
     build:
       context: webui
       dockerfile: Dockerfile
+    profiles: ["cpu", "gpu"]
     ports:
       - "${REACT_UI_PORT}:${REACT_UI_PORT}"
     volumes:
-      # Mount source code for development (live reload)
       - ./webui/src:/app/src
       - ./webui/public:/app/public
       - ./webui/package.json:/app/package.json
@@ -61,8 +79,6 @@ services:
       - REACT_UI_HTTPS=${REACT_UI_HTTPS}
       - SPEAKER_SERVICE_HOST=${SPEAKER_SERVICE_HOST}
       - SPEAKER_SERVICE_PORT=${SPEAKER_SERVICE_PORT}
-    depends_on:
-      - speaker-service
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "-k", "https://localhost:${REACT_UI_PORT}"]
@@ -73,14 +89,14 @@ services:
   # Nginx reverse proxy for unified HTTPS endpoint
   nginx:
     image: nginx:alpine
+    profiles: ["cpu", "gpu"]
     ports:
       - "8444:443"
-      - "8081:80"  
+      - "8081:80"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./ssl:/etc/nginx/ssl:ro
     depends_on:
-      - speaker-service
       - web-ui
     restart: unless-stopped
     healthcheck:


### PR DESCRIPTION
docker compose needs reference to the env file that we're using to get the env values, and I added some extra instructions to the README.  The docker compose has a deploy section which I've commented out as the default value is CPU.