### PR TITLE
add https profile to caddy service in docker compose

### DIFF
--- a/backends/advanced/docker-compose.yml
+++ b/backends/advanced/docker-compose.yml
@@ -105,6 +105,7 @@ services:
 
   # Caddy reverse proxy - provides HTTPS for microphone access
   # Access at: https://localhost (accepts self-signed cert warning)
+  # Only starts when HTTPS is configured (Caddyfile exists)
   caddy:
     image: caddy:2-alpine
     ports:
@@ -118,6 +119,8 @@ services:
       friend-backend:
         condition: service_healthy
     restart: unless-stopped
+    profiles:
+      - https
 
   # Development webui service (use with docker-compose --profile dev up)
   webui-dev:

--- a/services.py
+++ b/services.py
@@ -59,17 +59,24 @@ def run_compose_command(service_name, command, build=False):
     """Run docker compose command for a service"""
     service = SERVICES[service_name]
     service_path = Path(service['path'])
-    
+
     if not service_path.exists():
         console.print(f"[red]❌ Service directory not found: {service_path}[/red]")
         return False
-        
+
     compose_file = service_path / service['compose_file']
     if not compose_file.exists():
         console.print(f"[red]❌ Docker compose file not found: {compose_file}[/red]")
         return False
-    
+
     cmd = ['docker', 'compose']
+
+    # For backend service, check if HTTPS is configured (Caddyfile exists)
+    if service_name == 'backend':
+        caddyfile_path = service_path / 'Caddyfile'
+        if caddyfile_path.exists() and caddyfile_path.is_file():
+            # Enable HTTPS profile to start Caddy service
+            cmd.extend(['--profile', 'https'])
     
     # Handle speaker-recognition service specially
     if service_name == 'speaker-recognition' and command in ['up', 'down']:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selective service activation through profiles, enabling conditional startup of HTTPS and development environments
  * Automatic HTTPS enablement when running backend services with appropriate configuration

* **Chores**
  * Updated service configurations for improved deployment flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->