### PR TITLE
fixed deepgram worker script run

### DIFF
--- a/backends/advanced/start-workers.sh
+++ b/backends/advanced/start-workers.sh
@@ -80,8 +80,8 @@ start_workers() {
     echo "  - RQ worker 5: PID $RQ_WORKER_5_PID (transcription, memory, default)"
     echo "  - RQ worker 6: PID $RQ_WORKER_6_PID (transcription, memory, default)"
     echo "  - Audio persistence worker: PID $AUDIO_PERSISTENCE_WORKER_PID (audio queue - file rotation)"
-    [ -n "$AUDIO_STREAM_DEEPGRAM_WORKER_PID" ] && echo "  - Deepgram stream worker: PID $AUDIO_STREAM_DEEPGRAM_WORKER_PID (real-time transcription)"
-    [ -n "$AUDIO_STREAM_PARAKEET_WORKER_PID" ] && echo "  - Parakeet stream worker: PID $AUDIO_STREAM_PARAKEET_WORKER_PID (real-time transcription)"
+    [ -n "$AUDIO_STREAM_DEEPGRAM_WORKER_PID" ] && echo "  - Deepgram stream worker: PID $AUDIO_STREAM_DEEPGRAM_WORKER_PID (real-time transcription)" || true
+    [ -n "$AUDIO_STREAM_PARAKEET_WORKER_PID" ] && echo "  - Parakeet stream worker: PID $AUDIO_STREAM_PARAKEET_WORKER_PID (real-time transcription)" || true
 }
 
 # Function to check worker registration health


### PR DESCRIPTION
start-workers.sh was exiting if parakeet env was not set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced backend worker initialization to ensure graceful operation when optional worker processes are unavailable, improving overall system stability and robustness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->