### PR TITLE
Update Docker configuration to use PYTORCH_CUDA_VERSION instead of CU…

### DIFF
--- a/.github/workflows/advanced-docker-compose-build.yml
+++ b/.github/workflows/advanced-docker-compose-build.yml
@@ -199,7 +199,7 @@ jobs:
           cd ../../extras/asr-services
           for cuda_variant in cu121 cu126 cu128; do
             echo "Building parakeet-asr-${cuda_variant}"
-            export CUDA_VERSION="${cuda_variant}"
+            export PYTORCH_CUDA_VERSION="${cuda_variant}"
             docker compose build parakeet-asr
             
             img_id=$(docker compose images -q parakeet-asr | head -n1)

--- a/extras/asr-services/docker-compose-test.yml
+++ b/extras/asr-services/docker-compose-test.yml
@@ -31,7 +31,7 @@ services:
       context: .
       dockerfile: Dockerfile_Parakeet
       args:
-        CUDA_VERSION: ${CUDA_VERSION:-cu126}
+        PYTORCH_CUDA_VERSION: ${PYTORCH_CUDA_VERSION:-cu126}
     image: parakeet-asr:test
     ports:
       - "8767:8765"  # Different test port for parakeet


### PR DESCRIPTION
…DA_VERSION for Parakeet ASR builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration naming conventions for CUDA/PyTorch variant support consistency across container builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->