### PR TITLE
Update health check configuration in docker-compose-test.yml

### DIFF
--- a/backends/advanced/docker-compose-test.yml
+++ b/backends/advanced/docker-compose-test.yml
@@ -58,8 +58,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8000/readiness"]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 30s
+      retries: 10
+      start_period: 60s
     restart: unless-stopped
 
   webui-test:


### PR DESCRIPTION
- Increased the number of retries from 5 to 10 for improved resilience during service readiness checks.
- Extended the start period from 30s to 60s to allow more time for services to initialize before health checks commence.