### PR TITLE
docs: clarify Docker requirements for WSL users

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -48,6 +48,10 @@ Think of it like having Siri/Alexa, but it's **your own AI** running on **your h
 - **Linux**: [Install Docker](https://docs.docker.com/engine/install/)
 - **After install**: Make sure Docker Desktop is running
 
+> **WSL Users**: Chronicle services will fail to start unless Docker
+> is installed and running inside WSL2
+> (or Docker Desktop with **WSL integration enabled**).
+
 **uv** (Python package manager):
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
### Summary
This PR clarifies Docker requirements for users running Chronicle under WSL2.

Several Chronicle services fail to start if Docker is not available inside WSL2
(or if Docker Desktop is installed without WSL integration enabled),
but this was not explicitly documented in the Quick Start guide.

This change adds a short note to help WSL users avoid common setup issues.

### Changes
- Added a WSL-specific note explaining that Docker must be:
  - installed and running inside WSL2, **or**
  - Docker Desktop must have **WSL integration enabled**

### Motivation
While setting up Chronicle on WSL, services failed silently due to Docker not
being accessible from WSL. Documenting this upfront should save new users
significant setup time and confusion.

### Scope
- Documentation-only change
- No functional or behavioral changes

### Related
- WSL + Docker startup failures during local setup

related to #267 