### PR TITLE
fix(vault-sync): validate pairing device IDs

### DIFF
--- a/backends/advanced/src/advanced_omi_backend/models/vault_sync.py
+++ b/backends/advanced/src/advanced_omi_backend/models/vault_sync.py
@@ -1,0 +1,12 @@
+"""Request models for the vault sync pairing broker."""
+
+from pydantic import BaseModel, Field
+
+# Syncthing's canonical device ID is eight groups of seven base32 characters.
+# Enforce that shape before the ID is interpolated into Syncthing REST paths.
+_DEVICE_ID_PATTERN = r"^[A-Z2-7]{7}(?:-[A-Z2-7]{7}){7}$"
+
+
+class PairRequest(BaseModel):
+    device_id: str = Field(pattern=_DEVICE_ID_PATTERN)
+    device_name: str = "mac"

--- a/backends/advanced/src/advanced_omi_backend/routers/modules/vault_sync_routes.py
+++ b/backends/advanced/src/advanced_omi_backend/routers/modules/vault_sync_routes.py
@@ -19,9 +19,9 @@ from pathlib import Path
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
 
 from advanced_omi_backend.auth import current_active_user
+from advanced_omi_backend.models.vault_sync import PairRequest
 from advanced_omi_backend.users import User
 
 logger = logging.getLogger(__name__)
@@ -66,11 +66,6 @@ async def _server_device_id(client: httpx.AsyncClient) -> str:
     resp = await client.get("/rest/system/status")
     resp.raise_for_status()
     return resp.json()["myID"]
-
-
-class PairRequest(BaseModel):
-    device_id: str
-    device_name: str = "mac"
 
 
 @router.get("/info")

--- a/backends/advanced/tests/test_vault_sync_routes.py
+++ b/backends/advanced/tests/test_vault_sync_routes.py
@@ -1,0 +1,26 @@
+import pytest
+from pydantic import ValidationError
+
+from advanced_omi_backend.models.vault_sync import PairRequest
+
+VALID_DEVICE_ID = "S7UKX27-GI7ZTXS-GC6RKUA-7AJGZ44-C6NAYEB-HSKTJQK-KJHU2NO-CWV7EQW"
+
+
+def test_pair_request_accepts_canonical_syncthing_device_id():
+    request = PairRequest(device_id=VALID_DEVICE_ID)
+
+    assert request.device_id == VALID_DEVICE_ID
+
+
+@pytest.mark.parametrize(
+    "device_id",
+    [
+        "../../rest/system/shutdown",
+        f"{VALID_DEVICE_ID}?ignored=true",
+        VALID_DEVICE_ID.replace("-", ""),
+        "not-a-device-id",
+    ],
+)
+def test_pair_request_rejects_noncanonical_device_id(device_id):
+    with pytest.raises(ValidationError, match="device_id"):
+        PairRequest(device_id=device_id)


### PR DESCRIPTION
## Summary
- validate vault-sync pairing IDs as canonical Syncthing device IDs
- reject malformed IDs before they are interpolated into Syncthing REST paths
- move the request model into the backend models package and add focused regression tests

## History
The vault-sync implementation is already committed and present on `dev`. The macOS client and server broker landed through the June vault-sync commits included in merged PR #332. This is a small hardening follow-up discovered while reviewing that code.

## Testing
- `uv run --group test pytest tests/test_vault_sync_routes.py`
- `uv run black --check src/advanced_omi_backend/models/vault_sync.py src/advanced_omi_backend/routers/modules/vault_sync_routes.py tests/test_vault_sync_routes.py`
- `uv run isort --check-only src/advanced_omi_backend/models/vault_sync.py src/advanced_omi_backend/routers/modules/vault_sync_routes.py tests/test_vault_sync_routes.py`
- pre-commit and pre-push hooks